### PR TITLE
feat: Add photo input mode for AI generation

### DIFF
--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -79,7 +79,8 @@ async function fetchImageAsBase64(imageUrl: string): Promise<string> {
 export async function POST(req: Request) {
   try {
     console.log('[API] /api/generate: request received');
-    const { image, prompt } = await req.json();
+    // Destructure mimeType from the request
+    const { image, prompt, mimeType } = await req.json(); // Modified
     
     // Enhance prompt with beautification instruction
     // Format it more clearly to match the example
@@ -97,7 +98,10 @@ export async function POST(req: Request) {
     }
     
     console.log('[API] /api/generate: final prompt sent to AI:', enhancedPrompt);
-    console.log('[API] /api/generate: image length:', image ? image.length : 0);
+    console.log('[API] /api/generate: Received image base64 length:', image ? image.length : 'Not provided (or empty)'); // Modified for clarity
+    // Determine and log the MIME type
+    const actualMimeType = (typeof mimeType === 'string' && mimeType.trim() !== '') ? mimeType : 'image/png'; // New
+    console.log(`[API] /api/generate: using MIME type: ${actualMimeType}`); // New logging
     console.log('[API] /api/generate: first 100 chars of image:', image ? image.substring(0, 100) + '...' : 'No image data');
     
     const FAL_KEY = process.env.FAL_KEY;
@@ -105,8 +109,8 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: 'Missing FAL_KEY in environment' }, { status: 500 });
     }
     
-    // Create a data URI from the base64 image
-    const imageDataUrl = `data:image/png;base64,${image}`;
+    // Create a data URI from the base64 image using the actualMimeType
+    const imageDataUrl = `data:${actualMimeType};base64,${image}`; // Modified
     
     console.log('[API] /api/generate: submitting request to FAL.AI queue');
     const response = await fetch(


### PR DESCRIPTION
This commit introduces a new feature allowing you to upload a photo as the source for AI image generation, in addition to the existing sketch input mode.

Key changes:
- Modified `DudelCanvas.tsx` to include:
  - State management for input mode ('sketch' or 'photo') and photo data.
  - UI elements to switch between modes.
  - A file input for photo selection, with preview and clear options.
  - Conditional rendering of UI elements based on the selected mode.
- Updated the `handleGenerate` function to:
  - Use the uploaded photo data (as raw base64) when in 'photo' mode.
  - Retain existing canvas data handling for 'sketch' mode.
  - Ensure correct error handling and base64 formatting for both modes.
- Refined UI/UX:
  - Drawing tools are hidden when in photo mode.
  - "Clear" button functionality updated to "Clear All" to accommodate both canvas and photo clearing.
  - "Back to Drawing/Photo" button behavior adjusted for context.
- Enhanced robustness with `FileReader.onerror` handling for photo uploads.
- Ensured no regressions in the existing sketch mode functionality.